### PR TITLE
Deal with optionals early

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ of our rules as we can, so trust the warnings. Don’t commit or merge code with
 warnings. Our `Release` builds turn warnings into errors, so if you merge a
 warning you will create a problem for the person doing the release later on.
 
+### Don't allow optional parameters and then return when they're nil
+
+Don't allow optional parameters just to return when they're `nil`.
+
+```swift
+// Wrong: the return value becomes an optional as well.  Added complexity.
+func process(image: UIImage?) -> UIImage? {
+    if image == nil {
+        return nil
+    }
+
+    // ...process the image...
+}
+
+// Correct: the return value has a chance to become non-optional.  Reduced complexity.
+func process(image: UIImage) -> UIImage {
+    // ...process the image...
+}
+```
+
 ## All the rules
 
 ### Trailing new line

--- a/README.md
+++ b/README.md
@@ -37,19 +37,21 @@ warning you will create a problem for the person doing the release later on.
 Don't allow optional parameters just to return when they're `nil`.
 
 ```swift
+// Correct: the return value has a chance to become non-optional.  Reduced complexity.
+func process(image: UIImage) -> UIImage {
+    // ...process the image...
+}
+let processedImage = optionalImage.map(process)
+
 // Wrong: the return value becomes an optional as well.  Added complexity.
 func process(image: UIImage?) -> UIImage? {
-    if image == nil {
+    guard let image == image else {
         return nil
     }
 
     // ...process the image...
 }
-
-// Correct: the return value has a chance to become non-optional.  Reduced complexity.
-func process(image: UIImage) -> UIImage {
-    // ...process the image...
-}
+let processedImage = process(optionalImage)
 ```
 
 ## All the rules

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ of our rules as we can, so trust the warnings. Don’t commit or merge code with
 warnings. Our `Release` builds turn warnings into errors, so if you merge a
 warning you will create a problem for the person doing the release later on.
 
-### Don't allow optional parameters and then return when they're nil
+### Deal with optionals early
 
 Don't allow optional parameters just to return when they're `nil`.
 


### PR DESCRIPTION
In review until: May 25
Fixes #5 
Read about the [review process](https://github.com/wordpress-mobile/swift-style-guide/blob/master/PROCESS.md) and leave a comment with your vote.

---

Don't allow optional parameters just to return when they're `nil`.

``` swift
// Correct: the return value has a chance to become non-optional.  Reduced complexity.
func process(image: UIImage) -> UIImage {
    // ...process the image...
}
let processedImage = optionalImage.map(process)

// Wrong: the return value becomes an optional as well.  Added complexity.
func process(image: UIImage?) -> UIImage? {
    guard let image == image else {
        return nil
    }

    // ...process the image...
}
let processedImage = process(optionalImage)
```
