### PR TITLE
Adding closing braces guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ guard condition else { return }
 if condition { } else { }
 ```
 
-
 ### Forced downcasts and unwrapping
 
 Avoid using `as!` to force a downcast, or `!` to force unwrapping. Use `as?` to attempt the cast, then deal with the failure case explicitly.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ struct Foo
 }
 ```
 
-Closing braces should always be placed on a new line regardless of the numer of enclosed statements.
+Closing braces should always be placed on a new line regardless of the number of enclosed statements.
 
 ```
 // Correct

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ struct MyType : MyProtocol {}
 func prompt<T : UIViewController>(t: T) where T : Confirmable {}
 ```
 
-### Opening and closing braces
+### Braces
 
 Opening braces should be preceded by a single space and on the same line as the declaration. The exception to this rule is when enclosed within parentheses: no preceding space is required.
 
@@ -121,7 +121,7 @@ struct Foo
 }
 ```
 
-Closing braces should always be placed on a new line. No exceptions should be done, with regards of the numer of enclosed statements.
+Closing braces should always be placed on a new line regardless of the numer of enclosed statements.
 
 ```
 // Correct

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ struct MyType : MyProtocol {}
 func prompt<T : UIViewController>(t: T) where T : Confirmable {}
 ```
 
-### Opening braces
+### Opening and closing braces
 
 Opening braces should be preceded by a single space and on the same line as the declaration. The exception to this rule is when enclosed within parentheses: no preceding space is required.
 
@@ -120,6 +120,29 @@ struct Foo
     let bar: String
 }
 ```
+
+Closing braces should always be placed on a new line. No exceptions should be done, with regards of the numer of enclosed statements.
+
+```
+// Correct
+guard condition else {
+   return
+}
+
+// Correct
+if condition { 
+
+} else  {
+
+}
+
+// Wrong
+guard condition else { return }
+
+// Wrong
+if condition { } else { }
+```
+
 
 ### Forced downcasts and unwrapping
 


### PR DESCRIPTION
### Details:
As discussed on [the issue](https://github.com/wordpress-mobile/swift-style-guide/issues/13), in this PR we're adding a rule for **Closing Braces**.

Closes #13

Needs Review: @koke 
Thanks in advance!
